### PR TITLE
Updated success write for dataconv

### DIFF
--- a/06_update_dataconv_tables/update_dataconv_tables.Rmd
+++ b/06_update_dataconv_tables/update_dataconv_tables.Rmd
@@ -553,7 +553,7 @@ if(newAssets){
                            type = "Records",
                            hash = log_code)
   
-      dbWriteTable(mars, DBI::SQL("log.dataconv_writes"), logMessage, append = TRUE, row.names=FALSE)
+      dbWriteTable(mars, RPostgres::Id(schema = "log", table = "tbl_writes_dataconv"), logMessage, append = TRUE, row.names=FALSE)
     }
 
 


### PR DESCRIPTION
Quick fix for #1, but we should look at making all of these writes to the DB standard using a function. You can see an example from the liner app [here](https://github.com/PWD-MARS/liner/blob/822fd542bdd9989aa1cd972043fb90307720d97e/R/sql_write.R#L2-L23).

I didn't realize until after I wrote the fix that this was an issue that had been fixed in other chunks and this one had been overlooked.