### PR TITLE
Updated to read baro as EST then change to New_York

### DIFF
--- a/02_connectscripts/01_update_baro_tables.rmd
+++ b/02_connectscripts/01_update_baro_tables.rmd
@@ -316,7 +316,10 @@ for(i in 1:nrow(newfiles)){
   if(nrow(tempdata) == 0) {next} #if the file is empty, skip it
   tempdata <- tempdata[, 2:4]
   colnames(tempdata) <- c("dtime", "baro_psi", "temp_f")
-  tempdata$dtime <- mdy_hms(tempdata$dtime, tz = "America/New_York")
+  # Read dtime with EST time zone and change to America/New_York 
+  tempdata <- temp_data |>
+    mutate(dtime = mdy_hms(dtime, tz = "EST"),
+           dtime = with_tz(dtime, tz = "America/New_York"))
   tempdata$baro_rawfile_uid <- newfiles$baro_rawfile_uid[i]
   tempdata <- tempdata[complete.cases(tempdata[, 1:3]),] #Purge NA rows from the final data set
   


### PR DESCRIPTION
### Issue

Original code read baro time series as America/New_York, which applied the wrong TZ. This caused the baro data to be stored with America/New_York but it was really EST (#30) as well as complications downstream with the downloader app (https://github.com/PWD-MARS/shinyDownloadTools/issues/19)

### Resolution
Identified issue and verified in #30 as well as ran test to make sure it was correctly applying the change. Time zone is now being read in as EST, which matches the csv file, then is converted to America/New_York.

I would recommend running a larger test before merging since you will need to delete and reimport baro data from at least when the code was added to the baro file:

https://github.com/PWD-MARS/marsMaintenanceScripts/commit/5d5b9c04814de0a69087354a322c2d9d913c4b9d#diff-e6b1cf10e378a1cb72004fddf971df66bc8c7aa71bc7ec632ce2f6e2b887f4e2R165

Closes #30

