### PR TITLE
fixed typo with tempdata

### DIFF
--- a/02_connectscripts/01_update_baro_tables.rmd
+++ b/02_connectscripts/01_update_baro_tables.rmd
@@ -317,7 +317,7 @@ for(i in 1:nrow(newfiles)){
   tempdata <- tempdata[, 2:4]
   colnames(tempdata) <- c("dtime", "baro_psi", "temp_f")
   # Read dtime with EST time zone and change to America/New_York 
-  tempdata <- temp_data |>
+  tempdata <- tempdata |>
     mutate(dtime = mdy_hms(dtime, tz = "EST"),
            dtime = with_tz(dtime, tz = "America/New_York"))
   tempdata$baro_rawfile_uid <- newfiles$baro_rawfile_uid[i]


### PR DESCRIPTION
This caused the baro mainatenance script to stop. The error was not caught in the logs or in the maintenance dashboard.Script was successful upon fixing the typo

Fixes #34